### PR TITLE
Update repository URLs to reflect move to org

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/rvagg/string_decoder.git"
+    "url": "git://github.com/nodejs/string_decoder.git"
   },
-  "homepage": "https://github.com/rvagg/string_decoder",
+  "homepage": "https://github.com/nodejs/string_decoder",
   "keywords": [
     "string",
     "decoder",


### PR DESCRIPTION
So that links on the npm page and CLI commands like `npm docs` point to
the right place.