### PR TITLE
safe-buffer@~5.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "lib"
   ],
   "dependencies": {
-    "safe-buffer": "~5.1.0"
+    "safe-buffer": "~5.2.0"
   },
   "devDependencies": {
     "babel-polyfill": "^6.23.0",


### PR DESCRIPTION
The only change is this PR: https://github.com/feross/safe-buffer/pull/23

This should not affect the functionality of `string_decoder`.