### PR TITLE
Don't publish .travis.yml

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,3 @@
 build
 test
+.travis.yml


### PR DESCRIPTION
No need to include `.travis.yml` in the published package